### PR TITLE
feat(ci): add E2E pre-release trigger workflow with report-portal tagging

### DIFF
--- a/.github/workflows/e2e-main-tf.yaml
+++ b/.github/workflows/e2e-main-tf.yaml
@@ -16,6 +16,11 @@
 
 name: PD E2E Testing Farm
 
+run-name: >-
+  ${{ inputs.release_tag
+      && format('PD E2E Testing Farm [{0}]', inputs.release_tag)
+      || '' }}
+
 on:
   schedule:
     - cron:  '0 0 * * *'
@@ -31,6 +36,11 @@ on:
         description: 'TMT plan target to run (e.g. smoke, e2e, kubernetes, all)'
         type: string
         default: 'e2e'
+      release_tag:
+        description: 'Tag to identify this run for report-portal'
+        type: string
+        default: ''
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -17,6 +17,11 @@
 
 name: e2e-tests-main
 
+run-name: >-
+  ${{ inputs.release_tag
+      && format('e2e-tests-main [{0}]', inputs.release_tag)
+      || '' }}
+
 on:
   push:
     branches: [main]
@@ -74,6 +79,11 @@ on:
         - 'true'
         - 'false'
         default: 'true'
+        required: false
+      release_tag:
+        description: 'Tag to identify this run for report-portal'
+        type: string
+        default: ''
         required: false
 
 permissions:

--- a/.github/workflows/e2e-prerelease.yaml
+++ b/.github/workflows/e2e-prerelease.yaml
@@ -41,7 +41,8 @@ jobs:
             -f organization=podman-desktop \
             -f repositoryName=podman-desktop \
             -f npm_target=test:e2e:all \
-            -f branch=${{ github.event.release.name || github.ref_name }}
+            -f branch=${{ github.event.release.name || github.ref_name }} \
+            -f release_tag=release
 
   trigger-testing-farm:
     name: Trigger Testing Farm E2E tests
@@ -63,7 +64,8 @@ jobs:
           gh workflow run e2e-main-tf.yaml \
             --repo ${{ github.repository }} \
             -f podman_version="$PODMAN_VERSION" \
-            -f npm_target=all
+            -f npm_target=all \
+            -f release_tag=release
 
   trigger-managed-configuration:
     name: Trigger managed configuration tests
@@ -75,4 +77,5 @@ jobs:
         run: |
           gh workflow run managed-configuration.yaml \
             --repo ${{ github.repository }} \
-            --ref ${{ github.event.release.name || github.ref_name }}
+            --ref ${{ github.event.release.name || github.ref_name }} \
+            -f release_tag=release

--- a/.github/workflows/managed-configuration.yaml
+++ b/.github/workflows/managed-configuration.yaml
@@ -1,7 +1,18 @@
 name: Managed configuration tests
 
+run-name: >-
+  ${{ inputs.release_tag
+      && format('Managed configuration tests [{0}]', inputs.release_tag)
+      || '' }}
+
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Tag to identify this run for report-portal'
+        type: string
+        default: ''
+        required: false
   push:
     branches: [ main ]
 


### PR DESCRIPTION
## Summary
- Add `e2e-prerelease.yaml` workflow that triggers E2E tests on pre-release publish
- Dispatches `e2e-main.yaml`, `e2e-main-tf.yaml`, and `managed-configuration.yaml` via `gh workflow run`
- Add `release_tag` input and `run-name` to all three target workflows so `workflow_run.display_title` contains `[release]` — enabling the OpenShift EventListener to filter release-triggered runs for report-portal

## Test plan
- [x] Verified all YAML files parse correctly
- [ ] Create a test pre-release on the fork and confirm all 3 workflows are dispatched
- [ ] Verify `display_title` contains `[release]` in the workflow run payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)