### PR TITLE
feat(ci): add branch input to Testing Farm workflow

### DIFF
--- a/.github/workflows/e2e-main-tf.yaml
+++ b/.github/workflows/e2e-main-tf.yaml
@@ -36,6 +36,11 @@ on:
         description: 'TMT plan target to run (e.g. smoke, e2e, kubernetes, all)'
         type: string
         default: 'e2e'
+      branch:
+        default: 'main'
+        description: 'Podman Desktop repo branch'
+        type: string
+        required: false
       release_tag:
         description: 'Tag to identify this run for report-portal'
         type: string
@@ -73,6 +78,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1
         with:
           api_key: ${{ secrets.TF_TOKEN }}
+          git_ref: ${{ inputs.branch || github.ref }}
           create_github_summary: "false"
           compose: ${{ matrix.fedora-version }}
           tmt_plan_filter: 'name:/tests/tmt/plans/pd-e2e-plan/${{ env.NPM_TARGET }}'


### PR DESCRIPTION
## Summary
- Adds a `branch` workflow_dispatch input to `e2e-main-tf.yaml` (default: `main`)
- Passes it to `sclorg/testing-farm-as-github-action`'s `git_ref` so Testing Farm clones the correct branch/tag
- Falls back to `github.ref` for schedule/manual runs without the input
- Prerequisite for the prerelease workflow (`e2e-prerelease.yaml`) to dispatch TF tests against release tags

## Test plan
- [ ] Verify manual dispatch with `branch` input clones the correct ref
- [ ] Verify scheduled runs are unaffected (no `branch` input → falls back to `github.ref`)
- [ ] Verify YAML is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)