### PR TITLE
feat(ci): add branch input to Testing Farm workflow

### DIFF
--- a/.github/workflows/e2e-main-tf.yaml
+++ b/.github/workflows/e2e-main-tf.yaml
@@ -36,6 +36,11 @@ on:
         description: 'TMT plan target to run (e.g. smoke, e2e, kubernetes, all)'
         type: string
         default: 'e2e'
+      branch:
+        default: 'main'
+        description: 'Podman Desktop repo branch'
+        type: string
+        required: false
       release_tag:
         description: 'Tag to identify this run for report-portal'
         type: string
@@ -73,6 +78,7 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@230555baceb860aa468d216f1822974836b965d1
         with:
           api_key: ${{ secrets.TF_TOKEN }}
+          git_ref: ${{ inputs.branch || github.ref }}
           create_github_summary: "false"
           compose: ${{ matrix.fedora-version }}
           tmt_plan_filter: 'name:/tests/tmt/plans/pd-e2e-plan/${{ env.NPM_TARGET }}'


### PR DESCRIPTION
Allow callers to specify which branch/tag the Testing Farm should test against via a new `branch` workflow_dispatch input, passed to the TF action's `git_ref`. Defaults to `main`; falls back to `github.ref` for schedule/manual runs without the input.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
