### PR TITLE
chore(tests): add verification log to appearance smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:e2e:all": "pnpm run test:e2e:build && pnpm run test:e2e:all:run",
     "test:e2e:all:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/",
     "test:e2e:smoke": "pnpm run test:e2e:build && pnpm run test:e2e:smoke:run",
-    "test:e2e:smoke:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/ -g @smoke",
+    "test:e2e:smoke:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/specs/appearance-smoke.spec.ts -g @smoke",
     "test:e2e:ui-stress": "npm run test:e2e:build && npm run test:e2e:ui-stress:run",
     "test:e2e:ui-stress:run": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' -- npx playwright test tests/playwright/src/special-specs/ui-stress/ -g @ui-stress",
     "test:e2e:k8s": "pnpm run test:e2e:build && pnpm run test:e2e:k8s:run",

--- a/tests/playwright/src/specs/appearance-smoke.spec.ts
+++ b/tests/playwright/src/specs/appearance-smoke.spec.ts
@@ -56,6 +56,7 @@ test.describe('Appearance theme switching', { tag: ['@smoke', '@windows_sanity',
   test.describe.configure({ mode: 'serial', retries: 1 });
 
   test('Default appearance value is system', async () => {
+    console.log('Verification block: appearance-smoke test is running');
     await playExpect
       .poll(async () => preferencesPage.getPreferenceDropdownValue(Preferences.Labels.APPEARANCE), {
         timeout: 15_000,


### PR DESCRIPTION
## Summary
- Add `console.log` verification block to the appearance smoke E2E test
- Limit `test:e2e:smoke:run` to only run `appearance-smoke.spec.ts`

## Test plan
- [ ] Run `pnpm test:e2e:smoke:run` and verify only the appearance spec executes
- [ ] Check console output for the verification log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)