### PR TITLE
ci(e2e-main): remove fork checks and use WORKFLOW_PAT

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -93,8 +93,6 @@ jobs:
   e2e-tests:
     name: Run E2E tests - ${{ matrix.installation }}
     runs-on: ubuntu-24.04
-    # disable on forks as secrets are not available
-    if: github.event.repository.fork == false
     permissions:
       checks: write # required for mikepenz/action-junit-report
     strategy:
@@ -190,7 +188,7 @@ jobs:
       - name: Run E2E tests on Flatpak bundle
         if: matrix.installation == 'flatpak-build'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
           PODMANDESKTOP_CI_BOT_TOKEN: ${{ secrets.PODMANDESKTOP_CI_BOT_TOKEN }}
           TEST_PODMAN_MACHINE: 'true'
           SKIP_KIND_INSTALL: 'true'
@@ -238,8 +236,6 @@ jobs:
   win-update-e2e-test:
     name: ${{ matrix.os }} update e2e tests - ${{ matrix.installation }}
     runs-on: ${{ matrix.os }}
-    # disable on forks as secrets are not available
-    if: github.event.repository.fork == false
     permissions:
       checks: write # required for mikepenz/action-junit-report
     env:
@@ -362,8 +358,6 @@ jobs:
       matrix:
         os: [macos-26, macos-15-intel]
     runs-on: ${{ matrix.os }}
-    # disable on forks as secrets are not available
-    if: github.event.repository.fork == false
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- Removed `github.event.repository.fork == false` checks from all three jobs in the e2e-main workflow so it can run on forks
- Changed `GH_TOKEN` secret from `GITHUB_TOKEN` to `WORKFLOW_PAT` for the flatpak E2E test step

## Test plan
- [ ] Verify e2e-main workflow triggers correctly on fork pushes/dispatches
- [ ] Verify flatpak E2E tests authenticate using the `WORKFLOW_PAT` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)