### PR TITLE
fix(test): force podman6 install to skip testing-farm-tag-repository

### DIFF
--- a/tests/tmt/scripts/install-podman.sh
+++ b/tests/tmt/scripts/install-podman.sh
@@ -33,7 +33,7 @@ if [[ "$PODMAN_VERSION" == "podman6" ]]; then
         exit 1
     fi
     sudo dnf copr enable -y rhcontainerbot/f44-podman6
-    sudo dnf install -y podman
+    sudo dnf install -y podman --disablerepo=testing-farm-tag-repository
 # "nightly": latest nightly build from rhcontainerbot/podman-next COPR repository
 elif [[ "$PODMAN_VERSION" == "nightly" ]]; then
     sudo dnf copr enable -y rhcontainerbot/podman-next


### PR DESCRIPTION
dnf5 was preferring podman 5.8.4 from testing-farm-tag-repository over the f44-podman6 COPR build, causing the post-install version check to fail. Disable the competing repo for this install, same as the existing nightly path.

### What does this PR do?

### Screenshot / video of UI

<!-- If this PR is changing UI, please include
screenshots or screencasts showing the difference -->

### What issues does this PR fix or reference?

<!-- Include any related issues from Podman Desktop
repository (or from another issue tracker). -->

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- [ ] Tests are covering the bug fix or the new feature
